### PR TITLE
Fix model config loading & ingestion fallback

### DIFF
--- a/example/configs/example.yaml
+++ b/example/configs/example.yaml
@@ -13,8 +13,13 @@ hf_configuration:
 # === MODEL CONFIGURATION ===
 model_list: 
   # to use the default huggingface inference
+  - model_name: Qwen/Qwen2.5-VL-72B-Instruct
+    provider:  hf-inference # as a default value
+    api_key: $HF_TOKEN
+    max_concurrent_requests: 32
+  # to use the default huggingface inference
   - model_name: Qwen/Qwen2.5-72B-Instruct
-    provider: novita # or hf-inference
+    provider: novita # or another desired provider, the list of available providers is here: https://huggingface.co/docs/huggingface_hub/guides/inference#supported-providers-and-tasks
     api_key: $HF_TOKEN
     max_concurrent_requests: 32
 
@@ -42,7 +47,7 @@ pipeline:
   # to convert your documents to a huggingface dataset
   upload_ingest_to_hub:
     run: true
-    source_documents_dir: data/example/processed
+    source_documents_dir: example/data/processed
 
   # to create a global summary of your documents
   summarization:

--- a/yourbench/pipeline/handler.py
+++ b/yourbench/pipeline/handler.py
@@ -46,8 +46,8 @@ DEFAULT_STAGE_ORDER: List[str] = [
     "chunking",
     "single_shot_question_generation",
     "multi_hop_question_generation",
-    "deduplicate_single_shot_questions",
-    "deduplicate_multi_hop_questions",
+    # "deduplicate_single_shot_questions", #TODO: either remove or uncomment when implemented
+    # "deduplicate_multi_hop_questions",
     "lighteval",
 ]
 

--- a/yourbench/pipeline/upload_ingest_to_hub.py
+++ b/yourbench/pipeline/upload_ingest_to_hub.py
@@ -125,14 +125,12 @@ def run(config: dict[str, Any]) -> None:
     # Collect .md files
     md_file_paths = glob.glob(os.path.join(source_dir, "*.md"))
     if not md_file_paths:
-        logger.warning(f"No .md files found in '{source_dir}'. Stage will end with no output.")
-        return
+        raise FileNotFoundError(f"No .md files found in '{source_dir}'.")
 
     # Read them into Python objects
     ingested_documents = _collect_markdown_files(md_file_paths)
     if not ingested_documents:
-        logger.warning("No valid markdown documents found. No dataset to upload.")
-        return
+        raise FileNotFoundError(f"No valid markdown documents parsed in '{source_dir}'.")
 
     # Convert the ingested markdown docs to a Hugging Face Dataset
     dataset = _convert_ingested_docs_to_dataset(ingested_documents)


### PR DESCRIPTION
Fixes config loading in ingestion.py by correctly using provider from the model list. Enables correct usage of a visual model during ingestion. Introduces a hard failure in upload_ingest_to_hub.py if no markdown files are found or parsed, to avoid proceeding with empty datasets.

- `ingestion.py`
  - Removed local `ModelConfig`, now imported from utils
  - Properly loads `provider` from config
  - Improved logging and switched to f-strings

- `upload_ingest_to_hub.py`
  - Replaced warnings with `FileNotFoundError` if no `.md` files or documents are found

- `example.yaml`
  - Fixed `source_documents_dir` path **(sic!)**
  - Specified `model_list`


Small changes;
- `handler.py`
  - Commented out deduplication stages (not implemented yet)
