### PR TITLE
Add TruffleHog Secret Scanning GitHub Action

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,24 @@
+name: Scan Secret Leaks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Secret Scanning
+      uses: trufflesecurity/trufflehog@main
+      with:
+        extra_args: --results=verified,unknown


### PR DESCRIPTION
This GitHub Action automatically scans for secrets in code changes using [TruffleHog](https://github.com/trufflesecurity/trufflehog). It runs on:
- pushes to the main branch
- all pull requests

General usage is described [here](https://github.com/marketplace/actions/trufflehog-oss). 

The scan checks only the code changes in each commit and reports any verified or suspicious secrets it finds. This helps prevent accidentally committing sensitive data (API keys, passwords, tokens, etc.).