### PR TITLE
Throw relevant error when inference fails

### DIFF
--- a/yourbench/utils/inference_engine.py
+++ b/yourbench/utils/inference_engine.py
@@ -88,8 +88,8 @@ async def _get_response(model: Model, inference_call: InferenceCall) -> str:
 
     # Safe-guarding in case the response is missing .choices
     if not response or not response.choices:
-        logger.warning("Empty response or missing .choices from model {}", model.model_name)
-        return ""
+        logger.error("Empty response or missing .choices from model {}", model.model_name)
+        raise Exception("Failed Inference")
 
     finish_time = time.time()
     logger.debug(

--- a/yourbench/utils/inference_engine.py
+++ b/yourbench/utils/inference_engine.py
@@ -17,7 +17,7 @@ from huggingface_hub import AsyncInferenceClient
 
 load_dotenv()
 
-GLOBAL_TIMEOUT = 3600
+GLOBAL_TIMEOUT = 300
 
 
 @dataclass


### PR DESCRIPTION
When there's a failed inference (without `.choices`, an error must be raised so that it can be retried). 

Also change the timeout, so it's 5 minutes, instead of 1 hour.