### PR TITLE
remove creation of fallback row

### DIFF
--- a/yourbench/pipeline/multi_hop_question_generation.py
+++ b/yourbench/pipeline/multi_hop_question_generation.py
@@ -297,21 +297,8 @@ def _parse_and_build_final(
             if not qa_pairs:
                 # Fallback row if no parseable QAs
                 logger.warning(
-                    f"No parseable JSON for row={row_idx}, doc_id={doc_id} (model={model_name}). Creating fallback row."
+                    f"No parseable JSON for row={row_idx}, doc_id={doc_id} (model={model_name})."
                 )
-                fallback_row = MultiHopQuestionRow(
-                    document_id=doc_id,
-                    source_chunk_ids=source_chunk_ids,
-                    question="No question parsed",
-                    self_answer="No answer parsed",
-                    estimated_difficulty=5,
-                    self_assessed_question_type="unknown",
-                    generating_model=model_name,
-                    thought_process="",
-                    citations=[],
-                    raw_response=raw_resp,
-                )
-                final_multi_hop_questions.append(fallback_row.__dict__)
                 continue
 
             # Otherwise, process each QA pair


### PR DESCRIPTION
As discussed in #32 , it doesn't make sense to add this row, as users may look at it as a warning, and continue on. This usually masks a deeper problem (such as the API not working, etc), and it is bad practice to add these.

The first PR only addressed the single shot generation. This addresses the multi-hop generation case