### PR TITLE
Fix license name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ We use:
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache-2.0 License - see the [LICENSE](LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
The readme incorrectly stated the project is under the MIT license.