### PR TITLE
Add Support for Multi-Choice and Open-Ended Question Types

### DIFF
--- a/example/configs/advanced_example.yaml
+++ b/example/configs/advanced_example.yaml
@@ -207,18 +207,23 @@ pipeline:
     # You can add global instructions guiding question style, difficulty, domain specificity:
     # additional_instructions: "Generate factual, short-answer questions at a college level."
 
+    # Control the format of generated questions:
+    # question_type: "open-ended"   # "open-ended" (default): model generates the answer to the question
+    #                               # "multi-choice": model creates options (A), (B), (C), (D) and selects the correct one
+
     # If your documents are large, you can randomly sample chunks to reduce cost:
     # chunk_sampling:
     #   mode: "count"        # "count" or "percentage" or "all"
     #   value: 5             # e.g. pick 5 random chunks per doc 
     #   random_seed: 123
 
-  # 6) MULTI_HOP_QUESTION_GENERATION
-  # Uses the “multihop_chunks” created by the chunking stage. The model is prompted
-  # to integrate knowledge across multiple chunks, producing more complex questions.
   multi_hop_question_generation:
     run: true
     # additional_instructions: "Try to integrate multiple pieces of evidence across chunks to create deeper questions."
+
+    # Control the format of generated questions:
+    # question_type: "open-ended"   # "open-ended" (default): model generates the answer to the question
+    #                               # "multi-choice": model creates options (A), (B), (C), (D) and selects the correct one
 
     # Similarly, you can sample the multi-hop chunks to cut down on inference:
     # chunk_sampling:

--- a/yourbench/pipeline/chunking.py
+++ b/yourbench/pipeline/chunking.py
@@ -595,7 +595,11 @@ def _chunk_document_fast(
         list[SingleHopChunk]: A list of token-based chunks.
     """
     text = " ".join(sentences)
-    chunk_texts = split_into_token_chunks(text, chunk_tokens=l_max_tokens, overlap=0)
+    chunk_texts = split_into_token_chunks(
+        text,
+        chunk_tokens=l_max_tokens,
+        overlap=0,
+    )
 
     return [SingleHopChunk(chunk_id=f"{doc_id}_{i}", chunk_text=chunk) for i, chunk in enumerate(chunk_texts)]
 
@@ -645,7 +649,9 @@ def _multihop_chunking(
         num_multihops_target = max(1, total_single_hops // num_multihops_factor)
 
     if np.prod((num_multihops_target, effective_h_max)) > total_single_hops:
-        logger.warning(f"Target {num_multihops_target} is too high for given sample size and effective_h_max")
+        logger.warning(
+            f"Target {num_multihops_target} is too high for given sample size: {total_single_hops} and effective_h_max: {effective_h_max}"
+        )
         num_multihops_target = total_single_hops // effective_h_max
 
     logger.info(

--- a/yourbench/pipeline/ingestion.py
+++ b/yourbench/pipeline/ingestion.py
@@ -288,8 +288,13 @@ def _convert_document_to_markdown(file_path: str, output_dir: str, markdown_proc
     """
     logger.debug("Converting file: {}", file_path)
     try:
-        # Perform the file-to-markdown conversion
-        conversion_result = markdown_processor.convert(file_path)
+        # Skipping conversion if file already in markdown
+        if os.path.splitext(file_path)[1] == ".md":
+            with open(file_path, "r") as f:
+                content = f.read()
+        else:
+            # Perform the file-to-markdown conversion
+            content = markdown_processor.convert(file_path).text_content
 
         # Construct an output filename with .md extension
         base_name = os.path.basename(file_path)
@@ -298,7 +303,7 @@ def _convert_document_to_markdown(file_path: str, output_dir: str, markdown_proc
 
         # Write the converted Markdown to disk
         with open(output_file, "w", encoding="utf-8") as out_f:
-            out_f.write(conversion_result.text_content)
+            out_f.write(content)
 
         logger.info(f"Successfully converted '{file_path}' -> '{output_file}'.")
     except Exception as exc:

--- a/yourbench/pipeline/lighteval.py
+++ b/yourbench/pipeline/lighteval.py
@@ -171,10 +171,17 @@ def run(config: Dict[str, Any]) -> None:
         # chunk text is chunk_text_map[chunk_id] if it exists
         chunk_text = chunk_text_map.get(chunk_id, "")
 
+        # if multiple choice question convert to number
+        gold = row.get("self_answer", "")
+        if row.get("choices"):
+            gold = [ord(gold) - ord("A")]
+
         return {
             "question": row.get("question", ""),
             "additional_instructions": row.get("additional_instructions", ""),
             "ground_truth_answer": row.get("self_answer", ""),
+            "gold": gold,
+            "choices": row.get("choices", []),
             "question_category": row.get("self_assessed_question_type", "unknown"),
             "kind": "single_shot",
             "estimated_difficulty": row.get("estimated_difficulty", 5),
@@ -207,10 +214,17 @@ def run(config: Dict[str, Any]) -> None:
             if ctxt:
                 chunk_texts.append(ctxt)
 
+        # if multiple choice question convert to number
+        gold = row.get("self_answer", "")
+        if row.get("choices"):
+            gold = [ord(gold) - ord("A")]
+
         return {
             "question": row.get("question", ""),
             "additional_instructions": row.get("additional_instructions", ""),
             "ground_truth_answer": row.get("self_answer", ""),
+            "gold": gold,
+            "choices": row.get("choices", []),
             "question_category": row.get("self_assessed_question_type", "unknown"),
             "kind": "multi_hop",
             "estimated_difficulty": row.get("estimated_difficulty", 5),

--- a/yourbench/pipeline/multi_hop_question_generation.py
+++ b/yourbench/pipeline/multi_hop_question_generation.py
@@ -12,8 +12,8 @@ Purpose:
 --------
 This module implements the multi-hop question generation stage within the YourBench pipeline.
 It processes a dataset of documents—each containing a list of multi-hop chunks—and generates
-multi-hop questions requiring integrative reasoning across those chunks. It uses a large
-language model to produce question-answer pairs in JSON format.
+multi-hop questions requiring integrative reasoning across those chunks. It uses a Large
+Language Model (LLM) to produce question-answer pairs in JSON format.
 
 Usage:
 ------
@@ -26,8 +26,8 @@ This module is typically invoked as part of the overall YourBench pipeline. It e
 
 The module then:
 1. Optionally samples multi-hop chunks from each document.
-2. Prompts a large language model to generate multi-hop question-answer pairs.
-3. Parses and saves the generated questions in a structured dataset.
+2. Prompts a Large Language Model (LLM) to generate multi-hop question-answer pairs.
+3. Parses and saves the generated questions in a structured HuggingFace `Dataset`.
 
 Error Handling and Logging:
 ---------------------------
@@ -38,13 +38,13 @@ Error Handling and Logging:
 
 Module-Level Dependencies:
 --------------------------
+- Requires Python 3.9+ for modern type annotations (`list[...]`, `dict[...]`).
 - Relies on the shared pipeline utilities (e.g., `yourbench.utils.dataset_engine`,
   `yourbench.utils.inference_engine`, `yourbench.utils.prompts`).
 - Preserves the existing signature and functionality for downstream consistency.
 """
-
 import random
-from typing import Any, Dict, List
+from typing import Any, Dict
 from dataclasses import field, dataclass
 
 from loguru import logger
@@ -73,11 +73,11 @@ class QuestionAnswerPair:
 
     question: str
     answer: str
-    choices: List[str]
+    choices: list[str]
     estimated_difficulty: int = 5
     question_type: str = "unknown"
     thought_process: str = ""
-    citations: List[str] = field(default_factory=list)
+    citations: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         # Normalize fields
@@ -90,7 +90,7 @@ class QuestionAnswerPair:
             self.citations = []
 
         if not isinstance(self.choices, list):
-            self.citations = []
+            self.choices = []
 
 
 @dataclass
@@ -100,16 +100,16 @@ class MultiHopQuestionRow:
     """
 
     document_id: str
-    source_chunk_ids: List[str]
+    source_chunk_ids: list[str]
     additional_instructions: str
     question: str
     self_answer: str
-    choices: List[str]
+    choices: list[str]
     estimated_difficulty: int
     self_assessed_question_type: str
     generating_model: str
     thought_process: str
-    citations: List[str] = field(default_factory=list)
+    citations: list[str] = field(default_factory=list)
     raw_response: str = field(default="")
 
     @classmethod
@@ -117,7 +117,7 @@ class MultiHopQuestionRow:
         cls,
         qa_pair: QuestionAnswerPair,
         document_id: str,
-        source_chunk_ids: List[str],
+        source_chunk_ids: list[str],
         generating_model: str,
         raw_response: str = "",
         additional_instructions: str = "",
@@ -239,8 +239,8 @@ def _multihop_chunk_sampling_and_calls(dataset, stage_cfg: Dict[str, Any]):
 
 
 def _sample_multi_hop_chunks(
-    mh_chunks: List[Dict[str, Any]], chunk_sampling_cfg: Dict[str, Any]
-) -> List[Dict[str, Any]]:
+    mh_chunks: list[Dict[str, Any]], chunk_sampling_cfg: Dict[str, Any]
+) -> list[Dict[str, Any]]:
     """
     Sample multi-hop chunks based on the stage configuration.
     """
@@ -274,7 +274,7 @@ def _sample_multi_hop_chunks(
     return mh_chunks
 
 
-def _multihop_qa_generation(config: Dict[str, Any], inference_calls: List[InferenceCall]):
+def _multihop_qa_generation(config: Dict[str, Any], inference_calls: list[InferenceCall]):
     """
     Call the inference engine to get multi-hop Q&A responses.
     """
@@ -288,8 +288,8 @@ def _multihop_qa_generation(config: Dict[str, Any], inference_calls: List[Infere
 
 def _parse_and_build_final(
     config: Dict[str, Any],
-    responses_dict: Dict[str, List[str]],
-    call_index_map: List[tuple],
+    responses_dict: Dict[str, list[str]],
+    call_index_map: list[tuple],
     stage_config: Dict[str, Any],
 ) -> Dataset:
     """

--- a/yourbench/pipeline/multi_hop_question_generation.py
+++ b/yourbench/pipeline/multi_hop_question_generation.py
@@ -43,6 +43,7 @@ Module-Level Dependencies:
   `yourbench.utils.inference_engine`, `yourbench.utils.prompts`).
 - Preserves the existing signature and functionality for downstream consistency.
 """
+
 import random
 from typing import Any, Dict
 from dataclasses import field, dataclass

--- a/yourbench/utils/chunking_utils.py
+++ b/yourbench/utils/chunking_utils.py
@@ -1,9 +1,31 @@
+from typing import Callable, Optional
+
 import tiktoken
 
 
 def split_into_token_chunks(
-    text: str, chunk_tokens: int = 1024, overlap: int = 100, encoding_name: str = "cl100k_base"
+    text: str,
+    chunk_tokens: int = 1024,
+    overlap: int = 100,
+    encoding_name: str = "cl100k_base",
+    preprocess: Optional[Callable[[str], str]] = None,
 ) -> list[str]:
+    """
+    Splits text into token-based chunks, with optional preprocessing.
+
+    Args:
+        text (str): The input text.
+        chunk_tokens (int): Max tokens per chunk.
+        overlap (int): Number of overlapping tokens.
+        encoding_name (str): tiktoken encoding name.
+        preprocess (Optional[Callable[[str], str]]): Optional preprocessing function.
+
+    Returns:
+        list[str]: List of decoded text chunks.
+    """
+    if preprocess:
+        text = preprocess(text)
+
     enc = tiktoken.get_encoding(encoding_name)
     tokens = enc.encode(text)
     stride = chunk_tokens - overlap

--- a/yourbench/utils/prompts.py
+++ b/yourbench/utils/prompts.py
@@ -41,7 +41,7 @@ SUMMARIZATION_USER_PROMPT = """You are an AI assistant tasked with analyzing and
 Remember, your task is to provide a clear, accurate, and concise summary of the document's content, disregarding any web-related artifacts or unnecessary elements. For long documents, ensure your summary reflects the complete scope and structure of the content."""
 
 
-QUESTION_GENERATION_SYSTEM_PROMPT = """## Your Role
+QUESTION_GENERATION_SYSTEM_PROMPT_HEADER = """## Your Role
 
 You are an expert educational content creator specializing in crafting thoughtful, rich, and engaging questions based on provided textual information. Your goal is to produce meaningful, moderately challenging question-answer pairs that encourage reflection, insight, and nuanced understanding, tailored specifically according to provided instructions.
 
@@ -133,9 +133,9 @@ Conduct careful analysis within `<document_analysis>` XML tags, following these 
 - False-premise
 - Edge-case
 
-(You do not need to use every question type, only those naturally fitting the content and instructions.)
+(You do not need to use every question type, only those naturally fitting the content and instructions.)"""
 
-## Output Structure
+QUESTION_GENERATION_SYSTEM_PROMPT_OUTPUT = """## Output Structure
 
 Present your final output as JSON objects strictly adhering to this Pydantic model within `<output_json>` XML tags:
 
@@ -153,10 +153,58 @@ class QuestionAnswerPair(BaseModel):
 
 ## Output Format
 
-Begin by thoughtfully analyzing the provided text_chunk within `<document_analysis>` XML tags. Then present the resulting JSON-formatted QuestionAnswerPairs clearly within `<output_json>` XML tags.
+Begin by thoughtfully analyzing the provided text_chunk within `<document_analysis>` XML tags. Then present the resulting JSON-formatted QuestionAnswerPairs clearly within `<output_json>` XML tags."""
 
-## Important Notes
+QUESTION_GENERATION_SYSTEM_PROMPT_OUTPUT_MULTI = """## Output Structure
 
+Present your final output as JSON objects strictly adhering to this Pydantic model within `<output_json>` XML tags:
+
+```python
+class MultipleChoiceQuestion(BaseModel):
+    thought_process: str  # Rationale for the question and distractors
+    question_type: Literal["analytical", "application-based", "clarification",
+                           "counterfactual", "conceptual", "true-false",
+                           "factual", "false-premise", "edge-case"]
+    question: str
+    answer: str  # One of "A", "B", "C", or "D"
+    choices: List[str]  # Must contain exactly 4 items
+    estimated_difficulty: int  # 1-10
+    citations: List[str]  # Direct support from the text_chunk
+```
+
+## Output Format
+
+Begin by thoughtfully analyzing the provided <text_chunk> within <document_analysis> XML tags. Your analysis should identify the key concepts, technical details, and reasoning opportunities found in the text.
+
+Then present the resulting multiple-choice questions as valid JSON objects within <output_json> tags, strictly following this structure:
+
+<document_analysis>
+- Key concept: ...
+- Important facts: ...
+- Reasoning opportunities: ...
+</document_analysis>
+
+<output_json>
+[
+  {
+    "thought_process": "This question targets understanding of how the chunk explains the purpose of semantic chunking in document processing. Distractors are phrased using near-synonyms or subtle distortions of the true concept.",
+    "question_type": "conceptual",
+    "question": "What is the primary reason for using semantic chunking in document preprocessing?",
+    "choices": [
+      "(A) To compress the document into fewer tokens.",
+      "(B) To group content based on semantic similarity and token limits.",
+      "(C) To translate the text into multiple languages.",
+      "(D) To strip metadata and formatting from the input file."
+    ],
+    "answer": "B",
+    "estimated_difficulty": 6,
+    "citations": ["Semantic chunking partitions documents into coherent segments based on semantic similarity and token length constraints."]
+  },
+  ...
+]
+</output_json>"""
+
+QUESTION_GENERATION_SYSTEM_PROMPT_FOOTER = """## Important Notes
 - Strive to generate questions that inspire genuine curiosity, reflection, and thoughtful engagement.
 - Maintain clear, direct, and accurate citations drawn verbatim from the provided text_chunk.
 - Ensure complexity and depth reflect thoughtful moderation as guided by the additional instructions.
@@ -165,6 +213,16 @@ Begin by thoughtfully analyzing the provided text_chunk within `<document_analys
 - When generating questions, NEVER include phrases like 'as per the text,' 'according to the document,' or any similar explicit references. Questions should inherently integrate content naturally and stand independently without explicit references to the source material
 """
 
+QUESTION_GENERATION_SYSTEM_PROMPT = (
+    QUESTION_GENERATION_SYSTEM_PROMPT_HEADER
+    + QUESTION_GENERATION_SYSTEM_PROMPT_OUTPUT
+    + QUESTION_GENERATION_SYSTEM_PROMPT_FOOTER
+)
+QUESTION_GENERATION_SYSTEM_PROMPT_MULTI = (
+    QUESTION_GENERATION_SYSTEM_PROMPT_HEADER
+    + QUESTION_GENERATION_SYSTEM_PROMPT_OUTPUT_MULTI
+    + QUESTION_GENERATION_SYSTEM_PROMPT_FOOTER
+)
 
 QUESTION_GENERATION_USER_PROMPT = """<title>
 {title}
@@ -183,7 +241,7 @@ QUESTION_GENERATION_USER_PROMPT = """<title>
 </additional_instructions>"""
 
 
-MULTI_HOP_QUESTION_GENERATION_SYSTEM_PROMPT = """## Your Role
+MULTI_HOP_QUESTION_GENERATION_SYSTEM_HEADER = """## Your Role
 
 You are an expert educational content creator specialized in generating insightful and thoughtfully designed multi-hop questions. Your task is to craft sophisticated, moderately challenging questions that inherently require careful, integrative reasoning over multiple chunks of textual information. Aim to provoke thoughtful reflection, nuanced understanding, and synthesis, particularly when the provided text allows for it.
 
@@ -273,40 +331,28 @@ Perform careful analysis within `<document_analysis>` XML tags:
   - If, upon careful analysis, a chunk does not provide sufficient meaningful context or substantial educational relevance, explicitly note this in the `<document_analysis>` section and refrain from generating questions based on it.
 
 - **Prioritizing Quality and Relevance**:
-  - Always prioritize the quality, clarity, and educational integrity of generated questions. Do not force questions from unsuitable content.
+  - Always prioritize the quality, clarity, and educational integrity of generated questions. Do not force questions from unsuitable content."""
 
 
-## Output Structure
-
-Present output as JSON objects conforming strictly to the following Pydantic model within `<output_json>` XML tags:
-
-```python
-class QuestionAnswerPair(BaseModel):
-    thought_process: str # Explanation of integrative reasoning and rationale
-    question_type: Literal["analytical", "application-based", "clarification",
-                           "counterfactual", "conceptual", "true-false",
-                           "factual", "open-ended", "false-premise", "edge-case"]
-    question: str
-    answer: str
-    estimated_difficulty: int  # 1-10, moderately challenging as per additional instructions
-    citations: List[str]  # Exact supporting quotes from text_chunks
-```
-
-## Output Format
-
-First, thoroughly conduct your analysis within `<document_analysis>` XML tags. Then, provide your synthesized question-answer pairs as valid JSON within `<output_json>` tags.
-
-## Important Notes
+MULTI_HOP_QUESTION_GENERATION_SYSTEM_FOOTER = """## Important Notes
 - Prioritize depth and thoughtfulness in your reasoning paths.
 - Allow natural complexity to guide question formulation, aiming for moderate challenge.
 - Precisely cite verbatim excerpts from text chunks.
 - Clearly communicate your thought process for integrative reasoning.
 - Adhere strictly to JSON formatting and Pydantic validation requirements.
 - Generate questions that genuinely inspire deeper reflection or meaningful exploration of the provided content.
-- When generating questions, NEVER include phrases like 'as per the text,' 'according to the document,' or any similar explicit references. Questions should inherently integrate content naturally and stand independently without explicit references to the source material
+- When generating questions, NEVER include phrases like 'as per the text,' 'according to the document,' or any similar explicit references. Questions should inherently integrate content naturally and stand independently without explicit references to the source material"""
 
-"""
-
+MULTI_HOP_QUESTION_GENERATION_SYSTEM_PROMPT = (
+    MULTI_HOP_QUESTION_GENERATION_SYSTEM_HEADER
+    + QUESTION_GENERATION_SYSTEM_PROMPT_OUTPUT
+    + MULTI_HOP_QUESTION_GENERATION_SYSTEM_FOOTER
+)
+MULTI_HOP_QUESTION_GENERATION_SYSTEM_PROMPT_MULTI = (
+    MULTI_HOP_QUESTION_GENERATION_SYSTEM_HEADER
+    + QUESTION_GENERATION_SYSTEM_PROMPT_OUTPUT_MULTI
+    + MULTI_HOP_QUESTION_GENERATION_SYSTEM_FOOTER
+)
 
 MULTI_HOP_QUESTION_GENERATION_USER_PROMPT = """<title>
 {title}


### PR DESCRIPTION
**Highlights:**

- Questions can now be generated as either `"open-ended"` (default) or `"multi-choice"`, it's reflected in `advanced_example.yaml`
- For `"multi-choice"`, the dataset includes a `choices` column with options labeled (A)–(D) and a correct answer key
- To prevent LLM answer-position bias (e.g., always choosing B or C), multiple-choice answers are now randomly shuffled with deterministic seeding
- For `"open-ended"`, the `choices` field remains empty
- If ingestion is enabled and the input file is already Markdown, it is read directly
- Refactored prompts into modular components for easier maintenance and extension

✅ Verified correctness of the updated examples and dataset format
🧪 Integrated with Lighteval logic for consistent dataset evaluation across modes
