### PR TITLE
fix push to hub

### DIFF
--- a/yourbench/utils/dataset_engine.py
+++ b/yourbench/utils/dataset_engine.py
@@ -186,7 +186,7 @@ def custom_save_dataset(
     config: Dict[str, Any],
     subset: Optional[str] = None,
     save_local: bool = True,
-    push_to_hub: bool = False,
+    push_to_hub: bool = True,
 ) -> None:
     """
     Save a dataset subset locally and push it to Hugging Face Hub.


### PR DESCRIPTION
One of the default behaviors we expect and explicitly wish to support is the automatic push to hub. However, setting this to false breaks it.

Resetting it back to true