### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,5 +1,8 @@
 name: Quality
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/huggingface/yourbench/security/code-scanning/1](https://github.com/huggingface/yourbench/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to restrict the permissions of the `GITHUB_TOKEN`. Since the workflow only needs to read the repository contents (e.g., to check out code), we will set `contents: read`. This ensures that no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
