### PR TITLE
Update quickstart with correct run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ echo "HF_TOKEN=<your_huggingface_api_token>" >> .env              # Hugging Face
 echo "HF_ORGANIZATION=<your_hf_username_or_org>" >> .env          # (Optional) Organization name for dataset pushing
 
 # 3. Run the pipeline on the provided example config (uses sample docs and models)
-yourbench run --config example/configs/example.yaml
+yourbench run --config example/configs/simple_example.yaml
 
 # 4. (Optional) Run the pipeline on your own documents:
 yourbench run --config my_custom_config.yaml
 ```
 
-The **example configuration** `example/configs/example.yaml` (included in the repository) demonstrates a basic setup. It specifies sample documents and default models for each stage of the pipeline. In step 3 above, YourBench will automatically ingest the example documents, generate a set of Q\&A pairs, and output a Hugging Face Dataset containing the evaluation questions and answers.
+The **example configuration** `example/configs/simple_example.yaml` (included in the repository) demonstrates a basic setup. It specifies sample documents and default models for each stage of the pipeline. In step 3 above, YourBench will automatically ingest the example documents, generate a set of Q\&A pairs, and output a Hugging Face Dataset containing the evaluation questions and answers.
 
 For your own data, you can create a YAML config pointing to your documents and preferred models. For instance, you might specify a folder of PDFs or text files under a `documents` field, and choose which LLM to use for question generation. **YourBench is fully configurable** – you can easily **toggle stages** on or off and swap in different models. *For example: you could disable the summarization stage for very short texts, or use a powerful, large, API model for question generation while using a faster local model for summarization.* The possibilities are endless! Simply adjust the YAML, and the pipeline will accommodate it. (See the [usage example](https://github.com/huggingface/yourbench/blob/main/example/configs/advanced_example.yaml) for all available options!)
 


### PR DESCRIPTION
I was trying out the quickstart guide and just noticed the name of the example.yaml should be updated.

`yourbench run --config example/configs/simple_example.yaml`