### PR TITLE
Add Deduplication for Generated Questions

### DIFF
--- a/yourbench/pipeline/question_generation.py
+++ b/yourbench/pipeline/question_generation.py
@@ -35,6 +35,7 @@ from yourbench.utils.chunking_utils import get_sampling_cfg
 from yourbench.utils.dataset_engine import custom_load_dataset, custom_save_dataset, _create_cross_document_dataset
 from yourbench.utils.parsing_engine import (
     parse_multi_hop_responses,
+    _remove_duplicate_questions,
     parse_single_shot_responses,
 )
 from yourbench.utils.inference.inference_core import run_inference
@@ -90,6 +91,9 @@ def run_single_shot(config: dict[str, Any]) -> None:
     responses = run_inference(config=config, step_name=SINGLE_SHOT_KEY, inference_calls=inference_calls)
     final_rows = parse_single_shot_responses(responses, inference_index_map, stage_cfg)
 
+    # Remove duplicate questions
+    final_rows = _remove_duplicate_questions(final_rows)
+
     if final_rows:
         logger.info(f"Saving {len(final_rows)} single-shot questions.")
         custom_save_dataset(Dataset.from_list(final_rows), config=config, subset="single_shot_questions")
@@ -134,6 +138,10 @@ def run_multi_hop(config: dict[str, Any]) -> None:
             return
         responses = run_inference(config=config, step_name=MULTI_HOP_KEY, inference_calls=inference_calls)
         final_rows = parse_multi_hop_responses(responses, inference_index_map, stage_cfg)
+
+        # Remove duplicate questions
+        final_rows = _remove_duplicate_questions(final_rows)
+
         if final_rows:
             logger.info(f"Saving {len(final_rows)} {label} questions.")
             custom_save_dataset(Dataset.from_list(final_rows), config=config, subset=label)

--- a/yourbench/utils/parsing_engine.py
+++ b/yourbench/utils/parsing_engine.py
@@ -385,3 +385,35 @@ def shuffle_mcq(question_dict: dict) -> dict:
     question_dict["answer"] = new_answer_letter
 
     return question_dict
+
+
+def _remove_duplicate_questions(rows: list[dict]) -> list[dict]:
+    """
+    Removes duplicate question entries based on normalized question text.
+
+    This function compares questions by stripping extra whitespace and lowercasing,
+    but retains the original question formatting in the returned results.
+    Only exact duplicates after normalization are removed.
+    """
+    seen_questions = set()
+    deduped_rows = []
+
+    for row in rows:
+        question = row.get("question")
+        if question is None:
+            deduped_rows.append(row)
+            continue
+
+        # Normalize only for comparison
+        norm_question = " ".join(question.split()).strip().lower()
+
+        if norm_question not in seen_questions:
+            seen_questions.add(norm_question)
+            deduped_rows.append(row)
+
+    removed = len(rows) - len(deduped_rows)
+    if removed > 0:
+        logger.info(f"Removed {removed} duplicate questions. Final count: {len(deduped_rows)}")
+    else:
+        logger.info(f"No duplicate questions detected. Final count: {len(deduped_rows)}")
+    return deduped_rows


### PR DESCRIPTION
Generated datasets can sometimes include identical questions. This deduplication ensures cleaner, more diverse output and avoids redundancy when saving the final dataset.

Changes:
- Added `_remove_duplicate_questions()` to filter out duplicate questions based on normalized text.
- Integrated this function into single-shot and multi-hop (including cross-documents) question generations.
- Preserves original question formatting while comparing normalized forms to ensure duplicates are accurately identified.
- Logs the number of duplicates removed for transparency. 

Output example:
```
INFO     | yourbench.utils.parsing_engine:_remove_duplicate_questions:417 - No duplicate questions detected. Final count: 29
INFO     | yourbench.pipeline.question_generation:run_single_shot:98 - Saving 29 single-shot questions.
```