### PR TITLE
Add JSONL export functionality

### DIFF
--- a/tests/unit/test_dataset_engine.py
+++ b/tests/unit/test_dataset_engine.py
@@ -1,0 +1,186 @@
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from datasets import Dataset, DatasetDict
+from yourbench.utils.dataset_engine import (
+    _export_to_jsonl,
+    _extract_settings,
+    custom_save_dataset,
+)
+from yourbench.utils.configuration_engine import YourbenchConfig, HuggingFaceConfig
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+@pytest.fixture
+def sample_dataset():
+    """Create a sample dataset for testing."""
+    data = {
+        "question": ["What is 2+2?", "What is the capital of France?"],
+        "answer": ["4", "Paris"],
+        "difficulty": [1, 2],
+    }
+    return Dataset.from_dict(data)
+
+
+@pytest.fixture
+def sample_dataset_dict(sample_dataset):
+    """Create a sample DatasetDict for testing."""
+    return DatasetDict({
+        "train": sample_dataset,
+        "test": Dataset.from_dict({
+            "question": ["What is 3+3?"],
+            "answer": ["6"],
+            "difficulty": [1],
+        }),
+    })
+
+
+@pytest.fixture
+def mock_config_with_jsonl(temp_dir):
+    """Create a mock configuration with JSONL export enabled."""
+    hf_config = HuggingFaceConfig(
+        hf_dataset_name="test_dataset",
+        hf_organization="test_org",
+        hf_token="test_token",
+        local_dataset_dir=temp_dir / "datasets",
+        export_jsonl=True,
+        jsonl_export_dir=temp_dir / "jsonl_export",
+    )
+    return YourbenchConfig(hf_configuration=hf_config)
+
+
+class TestJsonlExport:
+    """Test JSONL export functionality."""
+
+    def test_export_single_dataset_to_jsonl(self, sample_dataset, temp_dir):
+        """Test exporting a single Dataset to JSONL."""
+        export_dir = temp_dir / "export"
+        _export_to_jsonl(sample_dataset, export_dir)
+
+        # Check file was created
+        jsonl_file = export_dir / "dataset.jsonl"
+        assert jsonl_file.exists()
+
+        # Check content
+        with open(jsonl_file, "r") as f:
+            lines = f.readlines()
+
+        assert len(lines) == 2
+
+        # Verify first row
+        row1 = json.loads(lines[0])
+        assert row1 == {"question": "What is 2+2?", "answer": "4", "difficulty": 1}
+
+        # Verify second row
+        row2 = json.loads(lines[1])
+        assert row2 == {"question": "What is the capital of France?", "answer": "Paris", "difficulty": 2}
+
+    def test_export_dataset_with_subset_name(self, sample_dataset, temp_dir):
+        """Test exporting a Dataset with a specific subset name."""
+        export_dir = temp_dir / "export"
+        _export_to_jsonl(sample_dataset, export_dir, subset="train")
+
+        jsonl_file = export_dir / "train.jsonl"
+        assert jsonl_file.exists()
+
+        with open(jsonl_file, "r") as f:
+            lines = f.readlines()
+        assert len(lines) == 2
+
+    def test_export_dataset_dict_to_jsonl(self, sample_dataset_dict, temp_dir):
+        """Test exporting a DatasetDict to multiple JSONL files."""
+        export_dir = temp_dir / "export"
+        _export_to_jsonl(sample_dataset_dict, export_dir)
+
+        # Check train subset
+        train_file = export_dir / "train.jsonl"
+        assert train_file.exists()
+        with open(train_file, "r") as f:
+            train_lines = f.readlines()
+        assert len(train_lines) == 2
+
+        # Check test subset
+        test_file = export_dir / "test.jsonl"
+        assert test_file.exists()
+        with open(test_file, "r") as f:
+            test_lines = f.readlines()
+        assert len(test_lines) == 1
+
+        # Check index file
+        index_file = export_dir / "index.json"
+        assert index_file.exists()
+        with open(index_file, "r") as f:
+            index_data = json.load(f)
+
+        assert index_data["subsets"] == ["train", "test"]
+        assert index_data["total_rows"] == 3
+
+    def test_export_creates_directory_if_not_exists(self, sample_dataset, temp_dir):
+        """Test that export creates the directory if it doesn't exist."""
+        export_dir = temp_dir / "new_dir" / "nested"
+        assert not export_dir.exists()
+
+        _export_to_jsonl(sample_dataset, export_dir)
+
+        assert export_dir.exists()
+        assert (export_dir / "dataset.jsonl").exists()
+
+    @patch("yourbench.utils.dataset_engine.load_from_disk")
+    @patch("yourbench.utils.dataset_engine._safe_save")
+    def test_custom_save_dataset_with_jsonl_export(
+        self, mock_safe_save, mock_load_from_disk, sample_dataset, mock_config_with_jsonl
+    ):
+        """Test custom_save_dataset with JSONL export enabled."""
+        # Mock load_from_disk to return None (no existing dataset)
+        mock_load_from_disk.side_effect = FileNotFoundError()
+
+        with patch("yourbench.utils.dataset_engine._export_to_jsonl") as mock_export:
+            custom_save_dataset(
+                sample_dataset, mock_config_with_jsonl, subset="train", save_local=True, push_to_hub=False
+            )
+
+            # Verify _export_to_jsonl was called
+            mock_export.assert_called_once()
+            args = mock_export.call_args[0]
+            assert isinstance(args[0], DatasetDict)  # Should be wrapped in DatasetDict
+            assert args[1] == mock_config_with_jsonl.hf_configuration.jsonl_export_dir
+            assert args[2] == "train"
+
+    def test_extract_settings_includes_jsonl_config(self, mock_config_with_jsonl):
+        """Test that _extract_settings properly extracts JSONL configuration."""
+        settings = _extract_settings(mock_config_with_jsonl)
+
+        assert settings.export_jsonl is True
+        assert settings.jsonl_export_dir == mock_config_with_jsonl.hf_configuration.jsonl_export_dir
+
+    def test_unicode_handling_in_jsonl(self, temp_dir):
+        """Test that JSONL export handles Unicode characters correctly."""
+        data = {"text": ["Hello 世界", "Émoji 🎉", "Ñoño"], "id": [1, 2, 3]}
+        dataset = Dataset.from_dict(data)
+
+        export_dir = temp_dir / "unicode_test"
+        _export_to_jsonl(dataset, export_dir)
+
+        jsonl_file = export_dir / "dataset.jsonl"
+        with open(jsonl_file, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        # Verify Unicode characters are preserved
+        row1 = json.loads(lines[0])
+        assert row1["text"] == "Hello 世界"
+
+        row2 = json.loads(lines[1])
+        assert row2["text"] == "Émoji 🎉"
+
+        row3 = json.loads(lines[2])
+        assert row3["text"] == "Ñoño"

--- a/yourbench/utils/configuration_engine.py
+++ b/yourbench/utils/configuration_engine.py
@@ -155,6 +155,8 @@ class HuggingFaceConfig(BaseModel):
     local_dataset_dir: Path | None = Path("data/saved_dataset")
     local_saving: bool = True
     upload_card: bool = True
+    export_jsonl: bool = False
+    jsonl_export_dir: Path | None = Path("data/jsonl_export")
 
     @field_validator("hf_organization", "hf_token")
     @classmethod
@@ -168,7 +170,7 @@ class HuggingFaceConfig(BaseModel):
         object.__setattr__(self, "hf_organization", _expand_env(self.hf_organization))
         return self
 
-    @field_validator("local_dataset_dir")
+    @field_validator("local_dataset_dir", "jsonl_export_dir")
     @classmethod
     def validate_path(cls, v: Union[str, Path, None]) -> Path | None:
         if v is None:
@@ -708,11 +710,13 @@ class YourbenchConfig(BaseModel):
         hf_config_data = data.get("hf_configuration", {})
         if hf_config_data:
             hf_config_data = {k: v for k, v in hf_config_data.items() if v is not None}
-        
+
         config_data = {
             "hf_configuration": HuggingFaceConfig(**hf_config_data),
             "pipeline_config": pipeline_config,
-            "model_list": [ModelConfig(**{k: v for k, v in m.items() if v is not None}) for m in data.get("model_list", [])],
+            "model_list": [
+                ModelConfig(**{k: v for k, v in m.items() if v is not None}) for m in data.get("model_list", [])
+            ],
             "model_roles": data.get("model_roles", {}),
             "debug": data.get("debug", False),
         }


### PR DESCRIPTION
## Summary
- Add JSONL export functionality to save datasets as JSONL files alongside parquet format
- Add configuration options `export_jsonl` and `jsonl_export_dir` to HuggingFaceConfig
- Export creates one JSONL file per dataset subset with an index.json for DatasetDicts

## Test plan
- [x] Added comprehensive unit tests in test_dataset_engine.py
- [x] Tested with sample datasets including Unicode, lists, dicts
- [x] Verified exported JSONL matches original dataset content
- [x] All tests pass
- [x] Code quality checks pass (make quality, make style)