### PR TITLE
Fix path resolution for --docs ./ parameter

### DIFF
--- a/yourbench/main.py
+++ b/yourbench/main.py
@@ -817,8 +817,8 @@ def _run_quick_mode(
 
             shutil.copy2(docs_path, raw_dir)
         else:
-            # Directory - use as is
-            raw_dir = docs_path
+            # Directory - resolve to absolute path to avoid issues
+            raw_dir = docs_path.resolve()
 
         # Create configuration matching default_example structure
         config = {


### PR DESCRIPTION
When using --docs ./ the relative path was being passed directly to the pipeline, causing it to include unrelated files. Now resolve to absolute path to ensure correct directory scoping.