### PR TITLE
Fix failing test in test_configuration_engine.py

### DIFF
--- a/tests/unit/test_configuration_engine.py
+++ b/tests/unit/test_configuration_engine.py
@@ -383,6 +383,7 @@ class TestIntegration:
             assert isinstance(config, YourbenchConfig)
             assert len(config.model_list) > 0
 
+    @patch.dict(os.environ, {"HF_TOKEN": "test_token"})
     def test_end_to_end_workflow(self):
         """Test a complete configuration workflow."""
         # Create a config

--- a/uv.lock
+++ b/uv.lock
@@ -2078,7 +2078,7 @@ wheels = [
 
 [[package]]
 name = "yourbench"
-version = "0.5.3"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncio" },

--- a/yourbench/main.py
+++ b/yourbench/main.py
@@ -136,11 +136,9 @@ def run_yourbench(
             raise typer.Exit(1)
 
         api_key = "$HF_TOKEN"
-        
+
         model_config = ModelConfig(
-            model_name=model_name, 
-            api_key=api_key,
-            max_concurrent_requests=max_concurrent_requests or 32
+            model_name=model_name, api_key=api_key, max_concurrent_requests=max_concurrent_requests or 32
         )
 
         # Set output directory


### PR DESCRIPTION
## Summary
- Mock HF_TOKEN environment variable in test_end_to_end_workflow to prevent validation error

## Test plan
- Run `uv run pytest tests/unit/test_configuration_engine.py` to verify all tests pass