### PR TITLE
make `push_to_hub` configurable

### DIFF
--- a/yourbench/pipeline/chunking.py
+++ b/yourbench/pipeline/chunking.py
@@ -117,7 +117,9 @@ def run(config: YourbenchConfig) -> None:
     # Add to dataset and save
     dataset = dataset.add_column("chunks", all_chunks)
     dataset = dataset.add_column("multihop_chunks", all_multihops)
-    custom_save_dataset(dataset=dataset, config=config, subset="chunked")
+    custom_save_dataset(
+        dataset=dataset, config=config, subset="chunked", push_to_hub=config.hf_configuration.push_to_hub
+    )
 
     # Log statistics
     total_chunks = sum(len(c) for c in all_chunks)

--- a/yourbench/pipeline/citation_score_filtering.py
+++ b/yourbench/pipeline/citation_score_filtering.py
@@ -97,5 +97,7 @@ def run(config: YourbenchConfig) -> None:
     lighteval_ds = replace_dataset_columns(lighteval_ds, columns_data)
 
     logger.info("Saving updated dataset with new citation score columns...")
-    custom_save_dataset(dataset=lighteval_ds, config=config, subset=stage_cfg.subset)
+    custom_save_dataset(
+        dataset=lighteval_ds, config=config, subset=stage_cfg.subset, push_to_hub=config.hf_configuration.push_to_hub
+    )
     logger.success("citation_score_filtering stage completed successfully.")

--- a/yourbench/pipeline/ingestion.py
+++ b/yourbench/pipeline/ingestion.py
@@ -217,5 +217,5 @@ def _upload_to_hub(config: YourbenchConfig, md_files: list[Path]):
         return
 
     dataset = Dataset.from_list(docs)
-    custom_save_dataset(dataset, config, subset="ingested")
+    custom_save_dataset(dataset, config, subset="ingested", push_to_hub=config.hf_configuration.push_to_hub)
     logger.info(f"Uploaded {len(docs)} documents to Hub")

--- a/yourbench/pipeline/prepare_lighteval.py
+++ b/yourbench/pipeline/prepare_lighteval.py
@@ -144,7 +144,9 @@ def run(config: YourbenchConfig) -> None:
             "related_chunks": [],
             "type": [],
         })
-        custom_save_dataset(empty_dataset, config=config, subset="prepared_lighteval")
+        custom_save_dataset(
+            empty_dataset, config=config, subset="prepared_lighteval", push_to_hub=config.hf_configuration.push_to_hub
+        )
         return
 
     # Prepare lookups from chunked dataset
@@ -308,5 +310,7 @@ def run(config: YourbenchConfig) -> None:
         return
 
     # Save dataset
-    custom_save_dataset(dataset=final_ds, config=config, subset=output_subset)
+    custom_save_dataset(
+        dataset=final_ds, config=config, subset=output_subset, push_to_hub=config.hf_configuration.push_to_hub
+    )
     logger.success("Prepared Lighteval dataset saved successfully.")

--- a/yourbench/pipeline/question_generation.py
+++ b/yourbench/pipeline/question_generation.py
@@ -63,7 +63,9 @@ def _save_questions(rows: list[dict], config: YourbenchConfig, subset: str) -> N
         return
 
     logger.info(f"Saving {len(clean_rows)} {subset}")
-    custom_save_dataset(Dataset.from_list(clean_rows), config=config, subset=subset)
+    custom_save_dataset(
+        Dataset.from_list(clean_rows), config=config, subset=subset, push_to_hub=config.hf_configuration.push_to_hub
+    )
 
 
 def run_single_shot(config: YourbenchConfig) -> None:

--- a/yourbench/pipeline/question_rewriting.py
+++ b/yourbench/pipeline/question_rewriting.py
@@ -213,7 +213,9 @@ def _process_question_type(
             return
 
         rewritten_ds = Dataset.from_list(rewritten_rows)
-        custom_save_dataset(dataset=rewritten_ds, config=config, subset=save_subset)
+        custom_save_dataset(
+            dataset=rewritten_ds, config=config, subset=save_subset, push_to_hub=config.hf_configuration.push_to_hub
+        )
         logger.success(f"Saved {len(rewritten_rows)} rewritten {question_type} questions.")
 
     except Exception as e:

--- a/yourbench/pipeline/summarization.py
+++ b/yourbench/pipeline/summarization.py
@@ -38,7 +38,9 @@ def run(config: YourbenchConfig) -> None:
     # Save results
     dataset = dataset.add_column("document_summary", final_summaries)
     dataset = dataset.add_column("summarization_model", [model_name] * len(dataset))
-    custom_save_dataset(dataset=dataset, config=config, subset="summarized")
+    custom_save_dataset(
+        dataset=dataset, config=config, subset="summarized", push_to_hub=config.hf_configuration.push_to_hub
+    )
     logger.success(f"Summarization complete for {len(dataset)} documents")
 
 

--- a/yourbench/utils/configuration_engine.py
+++ b/yourbench/utils/configuration_engine.py
@@ -158,6 +158,7 @@ class HuggingFaceConfig(BaseModel):
     upload_card: bool = True
     export_jsonl: bool = False
     jsonl_export_dir: Path | None = Path("data/jsonl_export")
+    push_to_hub: bool = True
 
     @field_validator("hf_organization", "hf_token")
     @classmethod


### PR DESCRIPTION
Addresses a related issue to #69 where users want to use models on private data but do not want to upload to hub.

- Adds `push_to_hub` to the `HuggingFaceConfig` dataclass
- Pushes this config down into every call of `custom_save_datase`, e.g 
```python
custom_save_dataset(
            dataset=<some dataset>, config=config, subset="this_stage", push_to_hub=config.hf_configuration.push_to_hub
        )
```

The default value is `True`, so existing pipelines should work without any changes to the config