### PR TITLE
fix: run real ingestion during token estimation

### DIFF
--- a/yourbench/utils/token_estimation.py
+++ b/yourbench/utils/token_estimation.py
@@ -122,13 +122,11 @@ def run_estimation_ingestion(
         content = _extract_file_content(file_path, processor)
         if content:
             tokens = count_tokens(content)
-            documents.append(
-                {
-                    "file_path": str(file_path),
-                    "content": content,
-                    "tokens": tokens,
-                }
-            )
+            documents.append({
+                "file_path": str(file_path),
+                "content": content,
+                "tokens": tokens,
+            })
             total_tokens += tokens
 
     return {
@@ -155,13 +153,11 @@ def simulate_chunking(documents: list[dict], chunk_max_tokens: int) -> list[dict
         doc_chunks = split_into_token_chunks(content, chunk_max_tokens, overlap=0)
         for i, chunk_text in enumerate(doc_chunks):
             chunk_tokens = count_tokens(chunk_text)
-            chunks.append(
-                {
-                    "doc_path": doc.get("file_path", ""),
-                    "chunk_index": i,
-                    "tokens": chunk_tokens,
-                }
-            )
+            chunks.append({
+                "doc_path": doc.get("file_path", ""),
+                "chunk_index": i,
+                "tokens": chunk_tokens,
+            })
 
     return chunks
 

--- a/yourbench/utils/token_estimation.py
+++ b/yourbench/utils/token_estimation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import tiktoken
 from loguru import logger
+from markitdown import MarkItDown
 
 
 if TYPE_CHECKING:
@@ -39,51 +40,144 @@ def count_file_tokens(file_path: Path, encoding_name: str = "cl100k_base") -> in
         return 0
 
 
-def estimate_source_tokens(source_dir: str, supported_extensions: list[str] = None) -> dict:
-    """Estimate tokens in source documents.
+def _extract_file_content(file_path: Path, processor: MarkItDown) -> str | None:
+    """Extract text content from a file using MarkItDown.
 
-    Returns dict with:
-        - total_tokens: Total input tokens
-        - file_count: Number of files
-        - files: Dict of file -> token count
+    This mirrors the ingestion pipeline logic but without LLM calls.
+    """
+    file_ext = file_path.suffix.lower()
+
+    try:
+        # Handle simple text files directly
+        if file_ext == ".md":
+            return file_path.read_text(encoding="utf-8")
+
+        if file_ext in {".txt", ".text"}:
+            return file_path.read_text(encoding="utf-8")
+
+        if file_ext in {".html", ".htm"}:
+            try:
+                import trafilatura
+
+                html = file_path.read_text(encoding="utf-8")
+                content = trafilatura.extract(
+                    html, output_format="markdown", include_comments=False, include_tables=True
+                )
+                if content:
+                    return content
+            except Exception:
+                pass
+
+        # Use MarkItDown for everything else (PDF, docx, etc.)
+        result = processor.convert(str(file_path))
+        return result.text_content if result else None
+
+    except Exception as e:
+        logger.debug(f"Error extracting content from {file_path}: {e}")
+        return None
+
+
+def run_estimation_ingestion(
+    source_dir: str,
+    supported_extensions: list[str] | None = None,
+    use_llm: bool = False,
+) -> dict:
+    """Run ingestion without LLM to extract document content for estimation.
+
+    Returns:
+        dict with:
+            - documents: list of {file_path, content, tokens}
+            - total_tokens: sum of all document tokens
+            - file_count: number of successfully processed files
+            - llm_required: True if LLM ingestion would be needed
     """
     if supported_extensions is None:
-        supported_extensions = [".md", ".txt", ".pdf"]
+        supported_extensions = [".md", ".txt", ".pdf", ".docx", ".html", ".htm"]
 
     source_path = Path(source_dir)
     if not source_path.exists():
-        return {"total_tokens": 0, "file_count": 0, "files": {}}
+        return {"documents": [], "total_tokens": 0, "file_count": 0, "llm_required": False}
 
-    files = {}
-    total = 0
+    # Initialize MarkItDown without LLM
+    processor = MarkItDown()
 
+    documents = []
+    total_tokens = 0
+    llm_required = False
+
+    # Collect all matching files
+    all_files = []
     for ext in supported_extensions:
-        for file_path in source_path.rglob(f"*{ext}"):
-            # Skip PDF for now - text extraction needed
-            if ext == ".pdf":
-                # Rough estimate: ~500 tokens per page, ~2 pages per PDF
-                tokens = 1000
-            else:
-                tokens = count_file_tokens(file_path)
-            files[str(file_path)] = tokens
-            total += tokens
+        all_files.extend(source_path.rglob(f"*{ext}"))
+
+    for file_path in all_files:
+        # Skip files in output directories
+        if "output" in str(file_path):
+            continue
+
+        # Check if this file type would need LLM ingestion for better quality
+        if use_llm and file_path.suffix.lower() == ".pdf":
+            llm_required = True
+
+        content = _extract_file_content(file_path, processor)
+        if content:
+            tokens = count_tokens(content)
+            documents.append(
+                {
+                    "file_path": str(file_path),
+                    "content": content,
+                    "tokens": tokens,
+                }
+            )
+            total_tokens += tokens
 
     return {
-        "total_tokens": total,
-        "file_count": len(files),
-        "files": files,
+        "documents": documents,
+        "total_tokens": total_tokens,
+        "file_count": len(documents),
+        "llm_required": llm_required,
     }
+
+
+def simulate_chunking(documents: list[dict], chunk_max_tokens: int) -> list[dict]:
+    """Simulate the chunking process to count actual chunks.
+
+    Returns list of chunks with token counts.
+    """
+    from yourbench.utils.chunking_utils import split_into_token_chunks
+
+    chunks = []
+    for doc in documents:
+        content = doc.get("content", "")
+        if not content:
+            continue
+
+        doc_chunks = split_into_token_chunks(content, chunk_max_tokens, overlap=0)
+        for i, chunk_text in enumerate(doc_chunks):
+            chunk_tokens = count_tokens(chunk_text)
+            chunks.append(
+                {
+                    "doc_path": doc.get("file_path", ""),
+                    "chunk_index": i,
+                    "tokens": chunk_tokens,
+                }
+            )
+
+    return chunks
 
 
 def estimate_pipeline_tokens(config: "YourbenchConfig") -> dict:
     """Estimate token usage for the full pipeline.
 
+    Runs actual ingestion (non-LLM) and chunking simulation for accurate estimates.
     Returns detailed breakdown of estimated input/output tokens per stage.
     """
     from yourbench.conf.loader import get_enabled_stages
 
     result = {
         "source_tokens": 0,
+        "source_file_count": 0,
+        "num_chunks": 0,
         "stages": {},
         "total_input_tokens": 0,
         "total_output_tokens": 0,
@@ -94,78 +188,89 @@ def estimate_pipeline_tokens(config: "YourbenchConfig") -> dict:
     if not enabled:
         return result
 
-    # Estimate source document tokens
+    # Run actual ingestion to get real document content
     source_dir = config.pipeline.ingestion.source_documents_dir
     exts = config.pipeline.ingestion.supported_file_extensions
-    source_info = estimate_source_tokens(source_dir, exts)
-    result["source_tokens"] = source_info["total_tokens"]
-    result["source_file_count"] = source_info["file_count"]
+    use_llm = config.pipeline.ingestion.llm_ingestion
+
+    logger.info(f"Running estimation ingestion on {source_dir}...")
+    ingestion_result = run_estimation_ingestion(source_dir, exts, use_llm)
+
+    result["source_tokens"] = ingestion_result["total_tokens"]
+    result["source_file_count"] = ingestion_result["file_count"]
+    result["llm_ingestion_required"] = ingestion_result["llm_required"]
 
     source_tokens = result["source_tokens"]
     if source_tokens == 0:
-        # Fallback estimate
-        source_tokens = 10000
+        logger.warning("No content extracted from source documents")
+        return result
+
+    # Simulate chunking to get accurate chunk count
+    chunk_max_tokens = config.pipeline.chunking.l_max_tokens
+    chunks = simulate_chunking(ingestion_result["documents"], chunk_max_tokens)
+    num_chunks = len(chunks)
+    result["num_chunks"] = num_chunks
+
+    # Calculate multi-hop combinations estimate
+    h_min = config.pipeline.chunking.h_min
+    h_max = config.pipeline.chunking.h_max
+    num_multihops_factor = config.pipeline.chunking.num_multihops_factor
+    num_multihop_combos = max(1, num_chunks // max(1, num_multihops_factor))
 
     total_input = 0
     total_output = 0
 
-    # Stage-by-stage estimation
+    # Stage-by-stage estimation with actual data
     for stage in enabled:
         stage_est = {"input_tokens": 0, "output_tokens": 0, "calls": 0}
 
         if stage == "ingestion":
-            # Ingestion reads files, may use LLM for PDF extraction
-            if config.pipeline.ingestion.llm_ingestion:
+            if use_llm:
+                # LLM ingestion processes each file
                 stage_est["input_tokens"] = source_tokens
-                stage_est["output_tokens"] = source_tokens  # Similar size output
-                stage_est["calls"] = source_info.get("file_count", 1)
+                stage_est["output_tokens"] = source_tokens
+                stage_est["calls"] = ingestion_result["file_count"]
             else:
                 stage_est["note"] = "No LLM calls (text extraction only)"
 
         elif stage == "summarization":
-            # Summarization processes all content
             max_tokens = config.pipeline.summarization.max_tokens
-            chunks = max(1, source_tokens // max_tokens)
-            stage_est["input_tokens"] = source_tokens + chunks * 500  # prompts
-            stage_est["output_tokens"] = chunks * 2000  # summaries
-            stage_est["calls"] = chunks
+            summary_chunks = max(1, source_tokens // max_tokens)
+            stage_est["input_tokens"] = source_tokens + summary_chunks * 500
+            stage_est["output_tokens"] = summary_chunks * 2000
+            stage_est["calls"] = summary_chunks
 
         elif stage == "chunking":
-            # Chunking is local, no LLM
             stage_est["note"] = "No LLM calls (local chunking)"
+            stage_est["chunks_created"] = num_chunks
 
         elif stage == "single_hop_question_generation":
-            # Estimate chunks and questions
-            chunk_size = config.pipeline.chunking.l_max_tokens
-            num_chunks = max(1, source_tokens // chunk_size)
-            stage_est["input_tokens"] = num_chunks * (chunk_size + 1000)  # chunk + prompt
-            stage_est["output_tokens"] = num_chunks * 1500  # ~3-5 QA pairs per chunk
+            avg_chunk_tokens = sum(c["tokens"] for c in chunks) // max(1, num_chunks)
+            prompt_overhead = 1000
+            stage_est["input_tokens"] = num_chunks * (avg_chunk_tokens + prompt_overhead)
+            stage_est["output_tokens"] = num_chunks * 1500
             stage_est["calls"] = num_chunks
 
         elif stage == "multi_hop_question_generation":
-            # Multi-hop uses chunk combinations
-            chunk_size = config.pipeline.chunking.l_max_tokens
-            num_chunks = max(1, source_tokens // chunk_size)
-            h_min = config.pipeline.chunking.h_min
-            h_max = config.pipeline.chunking.h_max
             avg_hops = (h_min + h_max) // 2
-            combinations = min(num_chunks, 20)  # Estimate combinations
-            stage_est["input_tokens"] = combinations * (chunk_size * avg_hops + 1000)
-            stage_est["output_tokens"] = combinations * 1500
-            stage_est["calls"] = combinations
+            avg_chunk_tokens = sum(c["tokens"] for c in chunks) // max(1, num_chunks)
+            prompt_overhead = 1000
+            stage_est["input_tokens"] = num_multihop_combos * (avg_chunk_tokens * avg_hops + prompt_overhead)
+            stage_est["output_tokens"] = num_multihop_combos * 1500
+            stage_est["calls"] = num_multihop_combos
 
         elif stage == "cross_document_question_generation":
-            # Cross-doc uses document combinations
             max_combos = config.pipeline.cross_document_question_generation.max_combinations
-            chunk_size = config.pipeline.chunking.l_max_tokens
-            docs_per_combo = sum(config.pipeline.cross_document_question_generation.num_docs_per_combination) // 2
-            stage_est["input_tokens"] = max_combos * (chunk_size * docs_per_combo + 1000)
+            docs_range = config.pipeline.cross_document_question_generation.num_docs_per_combination
+            docs_per_combo = sum(docs_range) // 2
+            avg_chunk_tokens = sum(c["tokens"] for c in chunks) // max(1, num_chunks)
+            prompt_overhead = 1000
+            stage_est["input_tokens"] = max_combos * (avg_chunk_tokens * docs_per_combo + prompt_overhead)
             stage_est["output_tokens"] = max_combos * 1500
             stage_est["calls"] = max_combos
 
         elif stage == "question_rewriting":
-            # Rewriting processes all generated questions
-            estimated_questions = source_tokens // 500  # Rough estimate
+            estimated_questions = num_chunks * 3
             stage_est["input_tokens"] = estimated_questions * 500
             stage_est["output_tokens"] = estimated_questions * 300
             stage_est["calls"] = estimated_questions


### PR DESCRIPTION
## Summary
Fixes the token estimation logic to use actual document content instead of hardcoded estimates.

## Changes
- Replace hardcoded 1K token estimate for PDFs with actual document extraction
- Use MarkItDown (without LLM) to extract content from PDFs, docx, etc.
- Simulate chunking to get accurate chunk counts
- Token estimates now based on real tiktoken encoding of actual content

## Before
```
Source Documents:
  Files: 1
  Estimated tokens: 1K  # hardcoded guess
```

## After
```
Source Documents:
  Files: 1
  Estimated tokens: 33.8K  # actual extracted content

Single Hop Question Generation:
  Input: 38.8K, Output: 7.5K, Calls: 5  # based on real chunk count
```

## Testing
- All 91 tests pass
- Verified with `yourbench estimate example/default_example/config.yaml`
- Verified with `yourbench estimate config.yaml` in harry_potter_quizz directory